### PR TITLE
Fix vector DB scoring preventing repeated tasks

### DIFF
--- a/vector_db/apps_db.py
+++ b/vector_db/apps_db.py
@@ -26,7 +26,7 @@ def add_app_command(command_text: str, action_type: str, action_target: str):
     print(f"✅ Команда сохранена: '{command_text}' → {action_target}")
 
 def search_command(user_input: str, threshold=0.8, k=1) -> dict | None:
-    results = apps_db.similarity_search_with_score(user_input, k=k)
+    results = apps_db.similarity_search_with_relevance_scores(user_input, k=k)
     if not results:
         return None
     doc, score = results[0]

--- a/vector_db/cromadb_interface.py
+++ b/vector_db/cromadb_interface.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
-from langchain.vectorstores import Chroma
-from langchain.embeddings import OllamaEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_community.embeddings import OllamaEmbeddings
 from langchain.schema.document import Document
 
 load_dotenv()
@@ -29,7 +29,7 @@ def add_command(text: str, action_dict: dict):
     print(f"✅ Добавлено в БД: '{text}' → {metadata}")
 
 def search_similar_command(query: str, k: int = 1, threshold: float = 0.8) -> dict | None:
-    results = db.similarity_search_with_score(query, k=k)
+    results = db.similarity_search_with_relevance_scores(query, k=k)
     if not results:
         return None
     doc, score = results[0]


### PR DESCRIPTION
## Summary
- use LangChain community wrappers consistently
- switch to `similarity_search_with_relevance_scores` so scoring is 0-1

## Testing
- `python -m py_compile vector_db/apps_db.py vector_db/cromadb_interface.py`

------
https://chatgpt.com/codex/tasks/task_e_685d56970e848321b27b571bce754e39