### PR TITLE
feat: add search_files action

### DIFF
--- a/core/actions.py
+++ b/core/actions.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import webbrowser
+from core.path_search import search_paths_interactive, ask_user_choose_path, open_path
 
 # Программы (пути можно дополнить под свою систему)
 APP_PATHS = {
@@ -47,6 +48,22 @@ def execute_action(action_type: str, action_target: str) -> str:
                 return f"Открываю {action_target}."
             else:
                 return f"⚠️ Путь {action_target} больше не существует."
+
+        elif action_type == "search_files":
+            paths_found = search_paths_interactive(action_target)
+            if paths_found:
+                if len(paths_found) == 1:
+                    open_path(paths_found[0])
+                    return f"Открываю {paths_found[0]}."
+                else:
+                    chosen = ask_user_choose_path(paths_found)
+                    if chosen:
+                        open_path(chosen)
+                        return f"Открываю {chosen}."
+                    else:
+                        return "Выбор отменён."
+            else:
+                return "Ничего не найдено."
 
         else:
             return "Неизвестный тип действия."

--- a/core/command_router.py
+++ b/core/command_router.py
@@ -78,7 +78,8 @@ def route_command(command_text: str) -> str:
     action = get_or_create_response(command_text, interpret_action)
 
     if action["action_type"] != "unknown":
-        add_app_command(command_text, action["action_type"], action["action_target"])
+        if action["action_type"] != "search_files":
+            add_app_command(command_text, action["action_type"], action["action_target"])
         return execute_action(action["action_type"], action["action_target"])
 
     # === Если LLM не поняла → короткий ответ

--- a/llm/action_interpreter.py
+++ b/llm/action_interpreter.py
@@ -14,6 +14,9 @@ EXAMPLES = """
 Вход: "выключи компьютер"
 Ответ: {"action_type": "shutdown", "action_target": "", "console_command": "shutdown /s /t 3"}
 
+Вход: "найди файл report"
+Ответ: {"action_type": "search_files", "action_target": "report", "console_command": ""}
+
 Вход: "прочитай анекдот"
 Ответ: {"action_type": "unknown", "action_target": "", "console_command": ""}
 """
@@ -31,8 +34,8 @@ def interpret_action(user_text: str) -> dict:
 }}
 
 Где:
-- action_type — тип действия (например: "launch_app", "open_folder", "open_url", "shutdown", "unknown")
-- action_target — цель (например: "browser", "Downloads", "https://youtube.com")
+- action_type — тип действия (например: "launch_app", "open_folder", "open_url", "search_files", "shutdown", "unknown")
+- action_target — цель (например: "browser", "Downloads", "report")
 - console_command — фактическая консольная команда, которая будет выполнена (например: "start chrome", "start D:\\Projects\\AI", "shutdown /s /t 3")
 
 Примеры:


### PR DESCRIPTION
## Summary
- allow the LLM action interpreter to classify `search_files` commands
- execute file searches via `search_paths_interactive`
- skip vector DB training for file search actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686554fffb7c8321b05c8a25f69a9764